### PR TITLE
Added 3 user authorization levels: tenant, landlord and superadmin.

### DIFF
--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -6,5 +6,4 @@ class Listing < ActiveRecord::Base
   validates :num_bedrooms, presence: true
   validates :num_bathrooms, presence: true
   validates :price, presence: true
-  validates :availability, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   include Clearance::User
   has_many :authentications, :dependent => :destroy
-  has_many :listings
+  has_many :listings, :dependent => :destroy
 
   def self.create_with_auth_and_hash(authentication,auth_hash)
     create! do |u|
@@ -20,4 +20,6 @@ class User < ActiveRecord::Base
   def password_optional?
     true
   end
+
+  enum role: [:tenant, :landlord, :superadmin]
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,8 @@
 <body>
   <%= link_to 'Home', root_path %><br>
   <% if signed_in? %>
-      Signed in as: <%= current_user.email %>
+      Signed in as: <%= current_user.email %><br>
+      Role: <%= current_user.role %>
       <%= button_to 'Sign out', sign_out_path, method: :delete %>
     <% else %>
       <%= link_to 'Sign up', sign_up_path %><br/>
@@ -19,7 +20,7 @@
 
     <div id="flash">
       <% flash.each do |key, value| %>
-        <div class="flash <%= key %>"><%= value %></div>
+        <div class="flash alert alert-<%= key %>"><%= value %></div>
       <% end %>
     </div>
 

--- a/app/views/listings/index.html.erb
+++ b/app/views/listings/index.html.erb
@@ -1,6 +1,7 @@
 <h1>Listings#index</h1>
-<h2><%= link_to "Create new listing", new_listing_path %></h2>
-<p>Find me in app/views/listings/index.html.erb</p>
+<% unless current_user.tenant? %>
+  <h2><%= link_to "Create new listing", new_listing_path %></h2>
+<% end %>
 
 <div class="table-responsive container-fluid">
   <table class="table table-hover table-bordered table-condensed">

--- a/db/migrate/20161123090158_add_role_to_users.rb
+++ b/db/migrate/20161123090158_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :role, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161123011319) do
+ActiveRecord::Schema.define(version: 20161123090158) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,13 +40,14 @@ ActiveRecord::Schema.define(version: 20161123011319) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
-    t.string   "email",                          null: false
-    t.string   "encrypted_password", limit: 128, null: false
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
+    t.string   "email",                                      null: false
+    t.string   "encrypted_password", limit: 128,             null: false
     t.string   "confirmation_token", limit: 128
-    t.string   "remember_token",     limit: 128, null: false
+    t.string   "remember_token",     limit: 128,             null: false
     t.string   "first_name"
+    t.integer  "role",                           default: 0
   end
 
   add_index "users", ["email"], name: "index_users_on_email", using: :btree


### PR DESCRIPTION
Tenant can't create/delete/edit listings and cannot view the "create a listing" button in the homepage.
Landlord can't edit or delete other landlord's listings.
Superadmin have authorization to edit, create, delete other people's listings.

-rails g migration AddRoleToUsers role:string, then add default value of 0 to it
-in users controller, i add "enum role: [:tenant, :landlord, :superadmin]" where 0 correspond with tenant
and 1 correspond with landlord and etc.